### PR TITLE
chore: add maintainers file

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,1 @@
+John Henderson <vcapi@j-henderson.com>


### PR DESCRIPTION
Adding a MAINTAINERS file in order to specify the folks responsible for maintaining the project, as per the project charter (which will be added in an upcoming commit)