### PR TITLE
test(issue e2e): issuance with remote context

### DIFF
--- a/apps/vc-api/package.json
+++ b/apps/vc-api/package.json
@@ -76,7 +76,7 @@
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^4.8.0",
-    "nock": "~13.3.1",
+    "nock": "^14.0.0",
     "@sphereon/pex-models": "~2.0.2",
     "@energyweb/eslint-config": "~0.1.0",
     "@energyweb/prettier-config": "~0.0.1",

--- a/apps/vc-api/test/vc-api/credentials/vc-api.e2e-suite.ts
+++ b/apps/vc-api/test/vc-api/credentials/vc-api.e2e-suite.ts
@@ -3,14 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as nock from 'nock';
 import * as request from 'supertest';
 import { CredentialDto } from '../../../src/vc-api/credentials/dtos/credential.dto';
 import { IssueOptionsDto } from '../../../src/vc-api/credentials/dtos/issue-options.dto';
 import { app, walletClient } from '../../app.e2e-spec';
 import { API_DEFAULT_VERSION_PREFIX } from '../../../src/setup';
+import { VerifyCredentialDto } from '../../../src/vc-api/credentials/dtos/verify-credential.dto';
 
 export const vcApiSuite = () => {
-  it('should issue using a generated did:key', async () => {
+  it('should issue simple credential using a generated did:key', async () => {
     const didDoc = await walletClient.createDID('key');
     const credential: CredentialDto = {
       '@context': ['https://www.w3.org/2018/credentials/v1'],
@@ -28,5 +30,50 @@ export const vcApiSuite = () => {
       .send({ credential, options })
       .expect(201);
     expect(postResponse.body).toBeDefined();
+  });
+
+  it('should issue credential with remote context using a generated did:key', async () => {
+    const didDoc = await walletClient.createDID('key');
+    const remoteContextBase = 'https://example.com';
+    const remoteContextPath = '/remote-ld-context';
+    const remoteContext = {
+      '@context': {
+        '@version': 1.1,
+        '@protected': true,
+        examplebase: `${remoteContextBase}${remoteContextPath}#`,
+        consent: 'examplebase:consent',
+        ConsentCredential: 'examplebase:ConsentCredential'
+      }
+    };
+    const contextLoadScope = nock(remoteContextBase)
+      .persist()
+      .get(remoteContextPath)
+      .reply(200, remoteContext);
+
+    const credential: CredentialDto = {
+      '@context': ['https://www.w3.org/2018/credentials/v1', `${remoteContextBase}${remoteContextPath}`],
+      id: 'urn:uuid:49f69fb8-f256-4b2e-b15d-c7ebec3a507e',
+      type: ['VerifiableCredential', 'ConsentCredential'],
+      credentialSubject: {
+        consent: 'I consent to such and such',
+        id: 'did:key:z6MkfGg96cNEL2Ne4z9HD3BSQhhD2neZKTzyE1y5wUu9KM4h'
+      },
+      issuer: didDoc.id,
+      issuanceDate: '2022-10-03T12:19:52Z'
+    };
+    const issueOptions: IssueOptionsDto = {};
+    const issueResponse = await request(app.getHttpServer())
+      .post(`${API_DEFAULT_VERSION_PREFIX}/vc-api/credentials/issue`)
+      .send({ credential, options: issueOptions })
+      .expect(201);
+    expect(issueResponse.body).toBeDefined();
+    contextLoadScope.done();
+
+    const verifiableCredential = issueResponse.body;
+    const verifyRequestBody: VerifyCredentialDto = { verifiableCredential };
+    await request(app.getHttpServer())
+      .post(`${API_DEFAULT_VERSION_PREFIX}/vc-api/credentials/verify`)
+      .send(verifyRequestBody)
+      .expect(200);
   });
 };

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -155,8 +155,8 @@ importers:
         specifier: ^29.5.0
         version: 29.7.0(@types/node@20.16.1)(ts-node@10.9.2)
       nock:
-        specifier: ~13.3.1
-        version: 13.3.8
+        specifier: ^14.0.0
+        version: 14.0.0
       prettier:
         specifier: ^2.8.8
         version: 2.8.8
@@ -3512,6 +3512,18 @@ packages:
     resolution: {integrity: sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==}
     dev: false
 
+  /@mswjs/interceptors@0.37.5:
+    resolution: {integrity: sha512-AAwRb5vXFcY4L+FvZ7LZusDuZ0vEe0Zm8ohn1FM6/X7A3bj4mqmkAcGRWuvC2JwSygNwHAAmMnAI73vPHeqsHA==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
+    dev: true
+
   /@multiformats/base-x@4.0.1:
     resolution: {integrity: sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==}
     dev: false
@@ -3851,6 +3863,21 @@ packages:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
+
+  /@open-draft/deferred-promise@2.2.0:
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+    dev: true
+
+  /@open-draft/logger@0.3.0:
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+    dev: true
+
+  /@open-draft/until@2.1.0:
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+    dev: true
 
   /@peculiar/asn1-cms@2.3.13:
     resolution: {integrity: sha512-joqu8A7KR2G85oLPq+vB+NFr2ro7Ls4ol13Zcse/giPSzUNN0n2k3v8kMpf6QdGUhI13e5SzQYN8AKP8sJ8v4w==}
@@ -5270,6 +5297,7 @@ packages:
   /@xmldom/xmldom@0.7.13:
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version is no longer supported, please update to at least 0.8.*
     dev: false
     optional: true
 
@@ -7625,6 +7653,7 @@ packages:
 
   /expo-random@14.0.1(expo@51.0.30):
     resolution: {integrity: sha512-gX2mtR9o+WelX21YizXUCD/y+a4ZL+RDthDmFkHxaYbdzjSYTn8u/igoje/l3WEO+/RYspmqUFa8w/ckNbt6Vg==}
+    deprecated: This package is now deprecated in favor of expo-crypto, which provides the same functionality. To migrate, replace all imports from expo-random with imports from expo-crypto.
     requiresBuild: true
     peerDependencies:
       expo: '*'
@@ -8870,6 +8899,10 @@ packages:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
     dev: false
+
+  /is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
+    dev: true
 
   /is-number-object@1.0.7:
     resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}
@@ -10663,15 +10696,13 @@ packages:
     dev: false
     optional: true
 
-  /nock@13.3.8:
-    resolution: {integrity: sha512-96yVFal0c/W1lG7mmfRe7eO+hovrhJYd2obzzOZ90f6fjpeU/XNvd9cYHZKZAQJumDfhXgoTpkpJ9pvMj+hqHw==}
-    engines: {node: '>= 10.13'}
+  /nock@14.0.0:
+    resolution: {integrity: sha512-3Z2ZoZoYTR/y2I+NI16+6IzfZFKBX7MrADtoBAm7v/QKqxQUhKw+Dh+847PPS1j/FDutjfIXfrh3CJF74yITWg==}
+    engines: {node: '>= 18'}
     dependencies:
-      debug: 4.3.6
+      '@mswjs/interceptors': 0.37.5
       json-stringify-safe: 5.0.1
       propagate: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /node-abi@3.67.0:
@@ -11015,6 +11046,10 @@ packages:
       os-tmpdir: 1.0.2
     dev: false
     optional: true
+
+  /outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
+    dev: true
 
   /p-finally@1.0.0:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
@@ -12319,6 +12354,10 @@ packages:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
 
+  /strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
+    dev: true
+
   /strict-uri-encode@2.0.0:
     resolution: {integrity: sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==}
     engines: {node: '>=4'}
@@ -12480,16 +12519,19 @@ packages:
 
   /sudo-prompt@8.2.5:
     resolution: {integrity: sha512-rlBo3HU/1zAJUrkY6jNxDOC9eVYliG6nS4JA8u8KAshITd07tafMc/Br7xQwCSseXwJ2iCcHCE8SNWX3q8Z+kw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     dev: false
     optional: true
 
   /sudo-prompt@9.1.1:
     resolution: {integrity: sha512-es33J1g2HjMpyAhz8lOR+ICmXXAqTuKbuXuUWLhOLew20oN9oUCgCJx615U/v7aioZg7IX5lIh9x34vwneu4pA==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     dev: false
     optional: true
 
   /sudo-prompt@9.2.1:
     resolution: {integrity: sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     dev: false
     optional: true
 


### PR DESCRIPTION
This PR is an example that a remote context can now be used for issuance and verification.
This is now another option in addition to inline contexts (as it is supported by Credo).
Updated nock as well as some issues with document loading calls.