### PR TITLE
fix(credential.dto): disallow empty type array

### DIFF
--- a/apps/vc-api/src/vc-api/credentials/dtos/credential.dto.ts
+++ b/apps/vc-api/src/vc-api/credentials/dtos/credential.dto.ts
@@ -3,7 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { IsArray, IsDateString, IsObject, IsOptional, IsString } from 'class-validator';
+import {
+  ArrayNotEmpty,
+  IsArray,
+  IsDateString,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString
+} from 'class-validator';
 import { ApiExtraModels, ApiProperty, ApiPropertyOptional, getSchemaPath } from '@nestjs/swagger';
 import { IsIssuer } from '../../exchanges/dtos/custom-validators';
 import { IssuerDto } from './issuer.dto';
@@ -30,6 +38,7 @@ export class CredentialDto {
   id?: string;
 
   @IsArray()
+  @ArrayNotEmpty()
   @IsString({ each: true })
   @ApiProperty({ description: 'The JSON-LD type of the credential.' })
   type: string[];


### PR DESCRIPTION
Needed for w3c-ccg test with empty array:
https://github.com/w3c-ccg/vc-api-issuer-test-suite/blob/cc7e18cd6a5e0ebcb2e73eaec79755422c8970c6/tests/10-issuer.js#L110